### PR TITLE
Msig signers fix

### DIFF
--- a/MsigProvider/NotASigner.test.tsx
+++ b/MsigProvider/NotASigner.test.tsx
@@ -58,6 +58,22 @@ describe('Not a signer error handling', () => {
         }
       })
 
+    jest
+      .spyOn(require('../apolloClient'), 'createApolloClient')
+      .mockImplementation(() => {
+        return {
+          query: ({ variables }) =>
+            Promise.resolve({
+              data: {
+                address: {
+                  id: variables.address,
+                  robust: variables.address
+                }
+              }
+            })
+        }
+      })
+
     const statePreset = 'postOnboard'
     const walletProviderInitialState = composeWalletProviderState(
       _walletProviderInitialState,

--- a/MsigProvider/index.test.tsx
+++ b/MsigProvider/index.test.tsx
@@ -60,6 +60,22 @@ describe('Multisig provider', () => {
           }
         })
 
+      jest
+        .spyOn(require('../apolloClient'), 'createApolloClient')
+        .mockImplementation(() => {
+          return {
+            query: ({ variables }) =>
+              Promise.resolve({
+                data: {
+                  address: {
+                    id: variables.address,
+                    robust: variables.address
+                  }
+                }
+              })
+          }
+        })
+
       const statePreset = 'postOnboard'
       const walletProviderInitialState = composeWalletProviderState(
         _walletProviderInitialState,

--- a/MsigProvider/index.tsx
+++ b/MsigProvider/index.tsx
@@ -1,5 +1,5 @@
 import { useState, createContext, ReactNode, useContext, Dispatch } from 'react'
-import { useAddressLazyQuery, useWallet } from '@glif/react-components'
+import { useWallet } from '@glif/react-components'
 import { FilecoinNumber } from '@glif/filecoin-number'
 import useSWR from 'swr'
 import { fetchMsigState } from '../utils/msig'
@@ -28,9 +28,8 @@ export const MsigProviderWrapper = ({
 }) => {
   const wallet = useWallet()
   const [msigActor, setMsigActor] = useState(null)
-  const [getAddress] = useAddressLazyQuery()
   const { data: actor, error: msigActorStateError } = useSWR(
-    msigActor ? [msigActor, wallet.address, getAddress] : null,
+    msigActor ? [msigActor, wallet.address] : null,
     fetchMsigState
   )
 

--- a/apolloClient.ts
+++ b/apolloClient.ts
@@ -19,26 +19,32 @@ const wsLink = process.browser
     })
   : null
 
-// The split function takes three parameters:
-//
-// * A function that's called for each operation to execute
-// * The Link to use for an operation if the function returns a "truthy" value
-// * The Link to use for an operation if the function returns a "falsy" value
-const link = process.browser //only create the split in the browser
-  ? split(
-      ({ query }) => {
-        const definition = getMainDefinition(query)
-        return (
-          definition.kind === 'OperationDefinition' &&
-          definition.operation === 'subscription'
-        )
-      },
-      wsLink,
-      httpLink
-    )
-  : httpLink
-
-export const apolloClient = new ApolloClient({
-  link,
-  cache: new InMemoryCache({ ...defaultMessageHistoryClientCacheConfig })
+export const cache = new InMemoryCache({
+  ...defaultMessageHistoryClientCacheConfig
 })
+
+export function createApolloClient() {
+  // The split function takes three parameters:
+  //
+  // * A function that's called for each operation to execute
+  // * The Link to use for an operation if the function returns a "truthy" value
+  // * The Link to use for an operation if the function returns a "falsy" value
+  const link = process.browser //only create the split in the browser
+    ? split(
+        ({ query }) => {
+          const definition = getMainDefinition(query)
+          return (
+            definition.kind === 'OperationDefinition' &&
+            definition.operation === 'subscription'
+          )
+        },
+        wsLink,
+        httpLink
+      )
+    : httpLink
+
+  return new ApolloClient({
+    link,
+    cache
+  })
+}

--- a/apolloClient.ts
+++ b/apolloClient.ts
@@ -19,28 +19,26 @@ const wsLink = process.browser
     })
   : null
 
-export function createApolloClient() {
-  // The split function takes three parameters:
-  //
-  // * A function that's called for each operation to execute
-  // * The Link to use for an operation if the function returns a "truthy" value
-  // * The Link to use for an operation if the function returns a "falsy" value
-  const link = process.browser //only create the split in the browser
-    ? split(
-        ({ query }) => {
-          const definition = getMainDefinition(query)
-          return (
-            definition.kind === 'OperationDefinition' &&
-            definition.operation === 'subscription'
-          )
-        },
-        wsLink,
-        httpLink
-      )
-    : httpLink
+// The split function takes three parameters:
+//
+// * A function that's called for each operation to execute
+// * The Link to use for an operation if the function returns a "truthy" value
+// * The Link to use for an operation if the function returns a "falsy" value
+const link = process.browser //only create the split in the browser
+  ? split(
+      ({ query }) => {
+        const definition = getMainDefinition(query)
+        return (
+          definition.kind === 'OperationDefinition' &&
+          definition.operation === 'subscription'
+        )
+      },
+      wsLink,
+      httpLink
+    )
+  : httpLink
 
-  return new ApolloClient({
-    link,
-    cache: new InMemoryCache({ ...defaultMessageHistoryClientCacheConfig })
-  })
-}
+export const apolloClient = new ApolloClient({
+  link,
+  cache: new InMemoryCache({ ...defaultMessageHistoryClientCacheConfig })
+})

--- a/components/Msig/Admin/Signers.tsx
+++ b/components/Msig/Admin/Signers.tsx
@@ -12,30 +12,28 @@ export const Signers = ({ signers }: { signers: AddressType[] }) => {
   const router = useRouter()
   return (
     <>
-      {signers.map((signer) => {
-        return (
-          <Address
-            key={signer.robust || signer.id}
-            address={signer}
-            onRemoveSigner={() => {
-              navigate(router, {
-                pageUrl: PAGE.MSIG_REMOVE_SIGNER,
-                newQueryParams: {
-                  address: signer.robust || signer.id
-                }
-              })
-            }}
-            onChangeSigner={() => {
-              navigate(router, {
-                pageUrl: PAGE.MSIG_CHANGE_SIGNER,
-                newQueryParams: {
-                  address: signer.robust || signer.id
-                }
-              })
-            }}
-          />
-        )
-      })}
+      {signers.map((signer) => (
+        <Address
+          key={signer.robust || signer.id}
+          address={signer}
+          onRemoveSigner={() => {
+            navigate(router, {
+              pageUrl: PAGE.MSIG_REMOVE_SIGNER,
+              newQueryParams: {
+                address: signer.robust || signer.id
+              }
+            })
+          }}
+          onChangeSigner={() => {
+            navigate(router, {
+              pageUrl: PAGE.MSIG_CHANGE_SIGNER,
+              newQueryParams: {
+                address: signer.robust || signer.id
+              }
+            })
+          }}
+        />
+      ))}
     </>
   )
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,3 +9,5 @@ import 'whatwg-fetch'
 process.env.NEXT_PUBLIC_LOTUS_NODE_JSONRPC =
   'https://calibration.node.glif.io/rpc/v0'
 process.env.NEXT_PUBLIC_COIN_TYPE = 't'
+process.env.NEXT_PUBLIC_GRAPH_API_URL =
+  'https://graph-calibration.glif.link/query'

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,7 +14,7 @@ import { ApolloProvider } from '@apollo/client'
 import { SWRConfig } from 'swr'
 import { MsigProviderWrapper } from '../MsigProvider'
 import { WasmLoader } from '../lib/WasmLoader'
-import { apolloClient } from '../apolloClient'
+import { createApolloClient } from '../apolloClient'
 import ErrorBoundary from '../components/ErrorBoundary'
 import JSONLD from '../JSONLD'
 
@@ -69,7 +69,7 @@ class MyApp extends App {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: JSON.stringify(JSONLD) }}
         />
-        <ApolloProvider client={apolloClient}>
+        <ApolloProvider client={createApolloClient()}>
           <SWRConfig value={{ refreshInterval: 10000 }}>
             <ThemeProvider theme={theme}>
               <WasmLoader>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,11 +14,9 @@ import { ApolloProvider } from '@apollo/client'
 import { SWRConfig } from 'swr'
 import { MsigProviderWrapper } from '../MsigProvider'
 import { WasmLoader } from '../lib/WasmLoader'
-import { createApolloClient } from '../apolloClient'
+import { apolloClient } from '../apolloClient'
 import ErrorBoundary from '../components/ErrorBoundary'
 import JSONLD from '../JSONLD'
-
-const client = createApolloClient()
 
 class MyApp extends App {
   render() {
@@ -71,7 +69,7 @@ class MyApp extends App {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: JSON.stringify(JSONLD) }}
         />
-        <ApolloProvider client={client}>
+        <ApolloProvider client={apolloClient}>
           <SWRConfig value={{ refreshInterval: 10000 }}>
             <ThemeProvider theme={theme}>
               <WasmLoader>

--- a/test-utils/constants.ts
+++ b/test-utils/constants.ts
@@ -7,8 +7,9 @@ export const WALLET_ADDRESS = 't1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi'
 export const MULTISIG_ACTOR_ADDRESS =
   'f2m4f2dv7m35skytoqzsyrh5wqz3kxxfflxsha5za'
 export const MULTISIG_SIGNER_ADDRESS = convertAddrToPrefix(WALLET_ADDRESS)
-export const MULTISIG_SIGNER_ADDRESS_2 =
+export const MULTISIG_SIGNER_ADDRESS_2 = convertAddrToPrefix(
   'f1nq5k2mps5umtebdovlyo7y6a3ywc7u4tobtuo3a'
+)
 
 export const signers = [
   {

--- a/utils/msig/fetchMsigState.test.ts
+++ b/utils/msig/fetchMsigState.test.ts
@@ -10,20 +10,21 @@ import {
   MULTISIG_SIGNER_ADDRESS_2
 } from '../../test-utils'
 
-jest.mock('../../apolloClient', () => ({
-  apolloClient: {
-    query: ({ variables }) =>
-      Promise.resolve({
-        data: {
-          address: {
-            id: variables.address,
-            robust: variables.address
+jest
+  .spyOn(require('../../apolloClient'), 'createApolloClient')
+  .mockImplementation(() => {
+    return {
+      query: ({ variables }) =>
+        Promise.resolve({
+          data: {
+            address: {
+              id: variables.address,
+              robust: variables.address
+            }
           }
-        }
-      })
-  }
-}))
-
+        })
+    }
+  })
 describe('fetchMsigState', () => {
   test('it returns an notMsigActor error if the actor is not a multisig', async () => {
     jest.spyOn(require('../actorCode'), 'decodeActorCID')

--- a/utils/msig/fetchMsigState.test.ts
+++ b/utils/msig/fetchMsigState.test.ts
@@ -12,14 +12,15 @@ import {
 
 jest.mock('../../apolloClient', () => ({
   apolloClient: {
-    query: ({ variables }) => Promise.resolve({
-      data: {
-        address: {
-          id: variables.address,
-          robust: variables.address
+    query: ({ variables }) =>
+      Promise.resolve({
+        data: {
+          address: {
+            id: variables.address,
+            robust: variables.address
+          }
         }
-      }
-    })
+      })
   }
 }))
 

--- a/utils/msig/fetchMsigState.test.ts
+++ b/utils/msig/fetchMsigState.test.ts
@@ -10,6 +10,19 @@ import {
   MULTISIG_SIGNER_ADDRESS_2
 } from '../../test-utils'
 
+jest.mock('../../apolloClient', () => ({
+  apolloClient: {
+    query: ({ variables }) => Promise.resolve({
+      data: {
+        address: {
+          id: variables.address,
+          robust: variables.address
+        }
+      }
+    })
+  }
+}))
+
 describe('fetchMsigState', () => {
   test('it returns an notMsigActor error if the actor is not a multisig', async () => {
     jest.spyOn(require('../actorCode'), 'decodeActorCID')
@@ -25,17 +38,7 @@ describe('fetchMsigState', () => {
         }
       })
 
-    const { errors } = await fetchMsigState(
-      'f01',
-      MULTISIG_SIGNER_ADDRESS,
-      // @ts-expect-error
-      () => {
-        return {
-          id: 'f01',
-          robust: 't26gmvesj3ercqmprmgvkcwxkaqir2crdosmbtpnd'
-        }
-      }
-    )
+    const { errors } = await fetchMsigState('f01', MULTISIG_SIGNER_ADDRESS)
 
     expect(errors.notMsigActor).toBe(true)
   }, 10000)
@@ -69,14 +72,7 @@ describe('fetchMsigState', () => {
 
     const { errors } = await fetchMsigState(
       't26gmvesj3ercqmprmgvkcwxkaqir2crdosmbtpny',
-      MULTISIG_SIGNER_ADDRESS,
-      // @ts-expect-error
-      () => {
-        return {
-          id: 'f01',
-          robust: 't26gmvesj3ercqmprmgvkcwxkaqir2crdosmbtpnd'
-        }
-      }
+      MULTISIG_SIGNER_ADDRESS
     )
 
     expect(errors.connectedWalletNotMsigSigner).toBe(true)
@@ -95,18 +91,7 @@ describe('fetchMsigState', () => {
 
     const { errors } = await fetchMsigState(
       't012914328591053',
-      MULTISIG_SIGNER_ADDRESS,
-      // @ts-ignore
-      () => {
-        return {
-          data: {
-            address: {
-              id: 'f01',
-              robust: 't26gmvesj3ercqmprmgvkcwxkaqir2crdosmbtpnd'
-            }
-          }
-        }
-      }
+      MULTISIG_SIGNER_ADDRESS
     )
 
     expect(errors.actorNotFound).toBe(true)
@@ -154,21 +139,7 @@ describe('fetchMsigState', () => {
       NumApprovalsThreshold,
       StartEpoch,
       UnlockDuration
-    } = await fetchMsigState(
-      MULTISIG_ACTOR_ADDRESS,
-      MULTISIG_SIGNER_ADDRESS_2,
-      // @ts-ignore
-      () => {
-        return {
-          data: {
-            address: {
-              robust: MULTISIG_SIGNER_ADDRESS_2,
-              id: ''
-            }
-          }
-        }
-      }
-    )
+    } = await fetchMsigState(MULTISIG_ACTOR_ADDRESS, MULTISIG_SIGNER_ADDRESS_2)
 
     expect(convertAddrToPrefix(Address)).toBe(
       convertAddrToPrefix(MULTISIG_ACTOR_ADDRESS)

--- a/utils/msig/fetchMsigState.tsx
+++ b/utils/msig/fetchMsigState.tsx
@@ -6,7 +6,7 @@ import { AddressDocument, AddressQuery } from '@glif/react-components'
 import isAddressSigner from './isAddressSigner'
 import { decodeActorCID } from '../actorCode'
 import { MsigActorState, emptyMsigState } from '../../MsigProvider/types'
-import { apolloClient } from '../../apolloClient'
+import { createApolloClient } from '../../apolloClient'
 
 export default async function fetchMsigState(
   actorID: string,
@@ -49,6 +49,7 @@ export default async function fetchMsigState(
       }
     }>('StateReadState', actorID, null)
 
+    const apolloClient = createApolloClient()
     const [availableBalance, signers] = await Promise.all([
       lCli.request<string>('MsigGetAvailableBalance', actorID, null),
       Promise.all(


### PR DESCRIPTION
See issue https://github.com/glifio/safe/issues/113

The GraphQL endpoint return the same data, but when using a lazy hook like this for multiple calls at the same time:
```javascript
const { data, error, loading } = await getAddress({
  variables: { address: s }
})
```

The returned `data` is the same for multiple calls, unless it is already stored in cache it seems.
The solution seems to be to use a normal `apolloClient.query()` call.