### PR TITLE
Fix issue with removing signers not applying

### DIFF
--- a/components/RemoveSigner/__snapshots__/index.test.tsx.snap
+++ b/components/RemoveSigner/__snapshots__/index.test.tsx.snap
@@ -1182,7 +1182,6 @@ exports[`RemoveSigner it renders the initial state correctly 1`] = `
             class="toggle-wrapper"
           >
             <input
-              checked=""
               disabled=""
               type="checkbox"
             />

--- a/components/RemoveSigner/index.tsx
+++ b/components/RemoveSigner/index.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useState, useMemo, Context } from 'react'
+import { useState, useMemo, Context, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { Message } from '@glif/filecoin-message'
 import { FilecoinNumber } from '@glif/filecoin-number'
@@ -34,9 +34,18 @@ export const RemoveSigner = ({
 
   // Input states
   const [signer, setSigner] = useState<string>(signerAddress)
-  const [decrease, setDecrease] = useState<boolean>(
-    Signers.length === NumApprovalsThreshold
-  )
+  const [decrease, setDecrease] = useState<boolean>(false)
+
+  // force a decrease if necessary
+  useEffect(() => {
+    if (
+      Signers.length > 1 &&
+      Signers.length === NumApprovalsThreshold &&
+      !decrease
+    ) {
+      setDecrease(true)
+    }
+  }, [Signers.length, NumApprovalsThreshold, decrease])
 
   // Transaction states
   const [txState, setTxState] = useState<TxState>(TxState.FillingForm)


### PR DESCRIPTION
Hey @navFooh this issue fixes a weird one that I'm surprised we didn't see before - invalid computation of `decrease` param in RemoveSigner.

Basically what happens (and i can't figure out if this was introduced recently from some other change or package upgrade) - the [initialState](https://github.com/glifio/safe/blob/primary/components/RemoveSigner/index.tsx#L38) of the `decrease` state variable is _always_ set to `true` because on first render, `NumApprovalsThreshold` and `Signers.length` are both undefined.

If the user doesn't toggle the decrease toggle button, then the value will _always_ be true, even if it shouldn't be.

There are two resulting not good scenarios (1) remove signer messages fail to get applied to the change since a user might have attempted to `decrease` when `NumApprovalThreshold` was already 1 or (2) approval thresholds _actually_ decrease when they shouldn't. 

I fixed this with a useEffect because it was the easiest way for me for now, but I'm not sold on this being the best approach here - it might make sense to have a default value, and then a user-set value (decrease) that overrides the default when it's set. This way we dont mess around with side effects 